### PR TITLE
refactor: split up ASDF step from the build/test

### DIFF
--- a/workflow-templates/elixir.yml
+++ b/workflow-templates/elixir.yml
@@ -3,8 +3,8 @@ name: Elixir CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build and test
+  asdf:
+    name: ASDF
     runs-on: ubuntu-latest
 
     steps:
@@ -19,17 +19,27 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@v1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      # if we did hit the cache, set up the environment
+
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    needs: asdf
+    steps:
+      - name: ASDF cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.asdf
+          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+        id: asdf-cache
       - name: Setup ASDF environment
         run: |
-          echo "ASDF_DIR=$HOME/.asdf" >> $GITHUB_ENV
-          echo "ASDF_DATA_DIR=$HOME/.asdf" >> $GITHUB_ENV
-        if: steps.asdf-cache.outputs.cache-hit == 'true'
-      - name: Reshim ASDF
-        run: |
+          ASDF_DIR=$HOME/.asdf
+          echo "ASDF_DIR=$ASDF_DIR" >> $GITHUB_ENV
+          echo "ASDF_DATA_DIR=$ASDF_DIR" >> $GITHUB_ENV
           echo "$ASDF_DIR/bin" >> $GITHUB_PATH
           echo "$ASDF_DIR/shims" >> $GITHUB_PATH
           $ASDF_DIR/bin/asdf reshim
+      - uses: actions/checkout@v2
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v2


### PR DESCRIPTION
This ensures we cache the ASDF build even if the other steps don't pass.

Based on work from @thecristen for mbta/dotcom.