### PR TITLE
feat: don't force strict mode for Credo

### DIFF
--- a/workflow-templates/elixir.yml
+++ b/workflow-templates/elixir.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
       - name: Credo
-        run: mix credo --strict
+        run: mix credo
       - name: Run tests
         run: mix test --cover
       - name: Save PR information


### PR DESCRIPTION
A suggestion-in-the-form-of-a-PR: Running Credo with `--strict` overrides any configured `strict` option in `.credo.exs`, preventing projects from enabling or disabling it as they like. Additionally, "strict" mode with the default Credo config enables a lot of kinda-subjective stylistic checks that don't allow for much nuance (like requiring nested modules to always be aliased, even if only used once), and failing CI if it doesn't pass seems a bit heavy-handed.

Of course, since the workflow setup involves copying this file to the target repo rather than "linking" to it, this is just a question of what the default should be; projects can always change it in their own copy of the file.