### PR TITLE
ci: configure Docker to use BuildKit

### DIFF
--- a/workflow-templates/deploy-ecs.yml
+++ b/workflow-templates/deploy-ecs.yml
@@ -12,6 +12,7 @@ jobs:
     environment: dev
     concurrency: dev
     env:
+      DOCKER_BUILDKIT: 1
       ECS_CLUSTER: __cluster_name__
       ECS_SERVICE: __service_name__
 

--- a/workflow-templates/deploy-elasticbeanstalk.yml
+++ b/workflow-templates/deploy-elasticbeanstalk.yml
@@ -13,6 +13,7 @@ jobs:
     concurrency: dev
     env:
       AWS_REGION: us-east-1
+      DOCKER_BUILDKIT: 1
       ELASTICBEANSTALK_APPLICATION_NAME: __application_name__
       ELASTICBEANSTALK_ENVIRONMENT_NAME: __environment_name__
 


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/build_enhancements/

BuildKit creates images more efficiently, running stages in parallel when
possible.