### PR TITLE
ci: cancel running CI workflows for current ref

### DIFF
--- a/workflow-templates/elixir.yml
+++ b/workflow-templates/elixir.yml
@@ -2,6 +2,10 @@ name: Elixir CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   asdf:
     name: ASDF


### PR DESCRIPTION
This change uses the concurrency feature to cancel running CI for the ref the workflow is running on, avoiding stale CI runs (inspired by [this](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run)). I think using `github.ref` will make it work for any ref, whereas `github.head_ref` will only do it for PRs, because there's no `github.base_ref` for a branch without a PR. The main difference between these for repos that only run CI on PRs is whether stale CI workflows for `main` will be canceled.