### PR TITLE
fix: move Hex/Rebar install up with the ASDF install

### DIFF
--- a/workflow-templates/elixir.yml
+++ b/workflow-templates/elixir.yml
@@ -23,6 +23,12 @@ jobs:
       # only run `asdf install` if we didn't hit the cache
       - uses: asdf-vm/actions/install@v1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
+      # only install Hex/Rebar if we didn't hit the cache
+      - if: steps.asdf-cache.outputs.cache-hit != 'true'
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+
 
   build:
     name: Build and test
@@ -47,11 +53,9 @@ jobs:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
-      - name: Install dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
+      - name: Install dependencies (if needed)
+        if: if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
       - name: Check formatting


### PR DESCRIPTION
Those packages are installed along with Elixir/Erlang in the ASDF directory.